### PR TITLE
Remove confusing exclamation point from end of filename in error message

### DIFF
--- a/src/Developer/OAuth/Utils/AuthenticationUtils.php
+++ b/src/Developer/OAuth/Utils/AuthenticationUtils.php
@@ -18,7 +18,7 @@ class AuthenticationUtils {
         try {
             $keystore = file_get_contents($pkcs12KeyFilePath);
         } catch (\Exception $e) {
-            throw new \InvalidArgumentException('Failed to read the given file: ' . $pkcs12KeyFilePath . '!', 0, $e);
+            throw new \InvalidArgumentException('Failed to read the given file: ' . $pkcs12KeyFilePath, 0, $e);
         }
 
         openssl_pkcs12_read($keystore, $certs, $signingKeyPassword);

--- a/tests/Developer/OAuth/Utils/AuthenticationUtilsTest.php
+++ b/tests/Developer/OAuth/Utils/AuthenticationUtilsTest.php
@@ -55,7 +55,7 @@ class AuthenticationUtilsTest extends TestCase {
 
         // THEN
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to read the given file: ./resources/some file!');
+        $this->expectExceptionMessage('Failed to read the given file: ./resources/some file');
 
         // GIVEN
         $keyContainerPath = './resources/some file';


### PR DESCRIPTION
This exclamation point isn't necessary and creates developer confusion, as it reads as though the "!" is part of the filename.